### PR TITLE
Change link to 2018 Challenges (was 2017)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 ## Vancouver Open Data Day Challenge
-*What VODDay Challenge is your project focusing on? (See the [2017 VODday Challenges](https://www.opendatabc.ca/pages/2017-vodday-vancouver-open-data-day#challenges).)*
+*What VODDay Challenge is your project focusing on? (See the [2018 VODday Challenges](https://www.opendatabc.ca/pages/vodday-2018-vancouver-open-data-day-hackathon#challenges).)*
 
 
 


### PR DESCRIPTION
It looks like the link to the "Challenges" wasn't updated from 2017. I updated both the link text and the link destination.